### PR TITLE
update to php7.3 node 11.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,14 +47,9 @@ RUN apt-get update && \
     php7.3-json \
     php7.3-xml \
     php7.3-intl \
-    # php7.3-pecl \
     # php7.3-mcrypt \
     php7.3-mbstring \
     composer
-
-# RUN bash -c "echo extension=/usr/lib/php/20170718/mcrypt.so > /etc/php/7.2/cli/conf.d/mcrypt.ini"
-# RUN bash -c "echo extension=/usr/lib/php/20170718/mcrypt.so > /etc/php/7.2/apache2/conf.d/mcrypt.ini"
-# RUN bash -c "echo extension=mcrypt.so > /etc/php/7.2/php.ini"
 
 RUN apt-get install -y ftp yarn nodejs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,16 +60,12 @@ RUN apt-get install -y ftp yarn nodejs
 
 USER root
 
-# preinstall annoying npm stuff
-# RUN npm install --unsafe --unsafe-perms -g n
-# RUN for ver in 4 5 6 7 8 9 10 11 latest; do n $ver; done
-RUN npm install --unsafe --unsafe-perms -g node-sass
-# RUN npm i -g node-sass
-
-RUN echo "node: $(node -v), npm: $(npm -v), yarn: $(yarn -v)"
+# preinstall heavy npm stuff
+RUN npm install --unsafe --unsafe-perms -g node-sass phantomjs-prebuilt
+RUN echo "node: $(node -v), npm: $(npm -v), yarn: $(yarn -v), php: $(php -v)"
 
 # cleanup
-RUN npm cache clean --force
+# RUN npm cache clean --force
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM ubuntu:latest
 LABEL maintainer="r.hoffmann@crolla-lowis.de"
 
 COPY .bashrc /root/.bashrc
-RUN export TERM=xterm
+ENV TERM=xterm
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo "Europe/Berlin" > /etc/timezone
 
 RUN apt-get clean && \
     apt-get update && \
@@ -16,43 +19,52 @@ RUN apt-get install -y \
     rsync \
     openssh-client \
     curl \
+    libmcrypt-dev \
+    libreadline-dev \
     libicu-dev \
     build-essential \
     libssl-dev \
     ftp-upload
 
 # add sources
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
 RUN LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php
 
 RUN apt-get update && \
     apt-get install -y \
-    php7.1 \
-    php7.1-cli \
-    php7.1-imagick \
-    php7.1-intl \
-    php7.1-curl \
-    php7.1-gd \
-    php7.1-zip \
-    php7.1-json \
-    php7.1-xml \
-    php7.1-mcrypt \
-    php7.1-mbstring \
+    php7.3 \
+    php7.3-cli \
+    php7.3-imagick \
+    php7.3-intl \
+    php7.3-apcu \
+    php7.3-mysql \
+    php7.3-pdo-mysql \
+    php7.3-curl \
+    php7.3-gd \
+    php7.3-zip \
+    php7.3-json \
+    php7.3-xml \
+    php7.3-intl \
+    # php7.3-pecl \
+    # php7.3-mcrypt \
+    php7.3-mbstring \
     composer
+
+# RUN bash -c "echo extension=/usr/lib/php/20170718/mcrypt.so > /etc/php/7.2/cli/conf.d/mcrypt.ini"
+# RUN bash -c "echo extension=/usr/lib/php/20170718/mcrypt.so > /etc/php/7.2/apache2/conf.d/mcrypt.ini"
+# RUN bash -c "echo extension=mcrypt.so > /etc/php/7.2/php.ini"
 
 RUN apt-get install -y ftp yarn nodejs
 
 USER root
 
-# RUN echo "node: $(node -v), npm: $(npm -v), yarn: $(yarn -v)"
-
 # preinstall annoying npm stuff
-RUN npm install --unsafe --unsafe-perms -g n
-RUN for ver in 4 5 6 7 8 9 latest; do n $ver; done
-RUN npm install --unsafe --unsafe-perms -g grunt gulp node-sass webpack
+# RUN npm install --unsafe --unsafe-perms -g n
+# RUN for ver in 4 5 6 7 8 9 10 11 latest; do n $ver; done
+RUN npm install --unsafe --unsafe-perms -g node-sass
+# RUN npm i -g node-sass
 
 RUN echo "node: $(node -v), npm: $(npm -v), yarn: $(yarn -v)"
 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,13 @@
 
 ## Changelog
 
+11.3.2019
+
+- Fix Node Version to 11
+- Update to PHP7.3
+- Remove php-mcrypt
+- Add php-intl
+
+before:
+
 - Updated to PHP7.1


### PR DESCRIPTION
should improve CI build performance when using node 11 which is now default.
use older tag :`7.1` for old projects.

closes #1 